### PR TITLE
Support querying a single 24h price change pair

### DIFF
--- a/Binance.API.Csharp.Client.Domain/Interfaces/IBinanceClient.cs
+++ b/Binance.API.Csharp.Client.Domain/Interfaces/IBinanceClient.cs
@@ -54,11 +54,17 @@ namespace Binance.API.Csharp.Client.Domain.Interfaces
         Task<IEnumerable<Candlestick>> GetCandleSticks(string symbol, TimeInterval interval, DateTime? startTime = null, DateTime? endTime = null, int limit = 500);
 
         /// <summary>
-        /// 24 hour price change statistics.
+        /// Single 24 hour price change statistics.
         /// </summary>
         /// <param name="symbol">Ticker symbol.</param>
         /// <returns></returns>
-        Task<IEnumerable<PriceChangeInfo>> GetPriceChange24H(string symbol);
+        Task<PriceChangeInfo> GetPriceChange24H(string symbol);
+
+        /// <summary>
+        /// All 24 hour price change statistics.
+        /// </summary>
+        /// <returns></returns>
+        Task<IEnumerable<PriceChangeInfo>> GetAllPriceChanges24H();
 
         /// <summary>
         /// Latest price for all symbols.

--- a/Binance.API.Csharp.Client.Test/BinanceTest.cs
+++ b/Binance.API.Csharp.Client.Test/BinanceTest.cs
@@ -45,9 +45,15 @@ namespace Binance.API.Csharp.Client.Test
         }
 
         [TestMethod]
-        public void GetPriceChange24H()
+        public void GetAllPriceChanges24H()
         {
-            var priceChangeInfo = binanceClient.GetPriceChange24H().Result;
+            var priceChangeInfo = binanceClient.GetAllPriceChanges24H().Result;
+        }
+
+        [TestMethod]
+        public void GetSinglePriceChanges24H()
+        {
+            var priceChangeInfo = binanceClient.GetPriceChange24H("ethbtc").Result;
         }
 
         [TestMethod]

--- a/Binance.API.Csharp.Client/BinanceClient.cs
+++ b/Binance.API.Csharp.Client/BinanceClient.cs
@@ -189,12 +189,21 @@ namespace Binance.API.Csharp.Client
         /// </summary>
         /// <param name="symbol">Ticker symbol.</param>
         /// <returns></returns>
-        public async Task<IEnumerable<PriceChangeInfo>> GetPriceChange24H(string symbol = "")
+        public async Task<PriceChangeInfo> GetPriceChange24H(string symbol)
         {
-            var args = string.IsNullOrWhiteSpace(symbol) ? "" : $"symbol={symbol.ToUpper()}";
+            var args = $"symbol={symbol.ToUpper()}";
+            var result = await _apiClient.CallAsync<PriceChangeInfo>(ApiMethod.GET, EndPoints.TickerPriceChange24H, false, args);
+            return result;
+        }
 
-            var result = await _apiClient.CallAsync<IEnumerable< PriceChangeInfo>>(ApiMethod.GET, EndPoints.TickerPriceChange24H, false, args);
-
+        /// <summary>
+        /// All 24 hour price change statistics.
+        /// </summary>
+        /// <param name="symbol">Ticker symbol.</param>
+        /// <returns></returns>
+        public async Task<IEnumerable<PriceChangeInfo>> GetAllPriceChanges24H()
+        {
+            var result = await _apiClient.CallAsync<IEnumerable<PriceChangeInfo>>(ApiMethod.GET, EndPoints.TickerPriceChange24H, false);
             return result;
         }
 


### PR DESCRIPTION
As mentioned in Ticket #15 the signature of the method GetPriceChange24H supports a symbol parameter but always expects a JSON Array to return the IEnumerable object.

When this parameter is provided the API returns a flat object, and not an array therefore this needs two different methods to support getting all price changes or a single price change.