### PR TITLE
Returning Websocket instead of void for methods which initiate listening to websockets

### DIFF
--- a/Binance.API.Csharp.Client.Domain/Interfaces/IApiClient.cs
+++ b/Binance.API.Csharp.Client.Domain/Interfaces/IApiClient.cs
@@ -1,6 +1,7 @@
 ﻿using Binance.API.Csharp.Client.Models.Enums;
 using Binance.API.Csharp.Client.Models.WebSocket;
 using System.Threading.Tasks;
+using WebSocketSharp;
 using static Binance.API.Csharp.Client.Domain.Abstract.ApiClientAbstract;
 
 namespace Binance.API.Csharp.Client.Domain.Interfaces
@@ -25,7 +26,7 @@ namespace Binance.API.Csharp.Client.Domain.Interfaces
         /// <param name="parameters">Paremeters to send to the Websocket.</param>
         /// <param name="messageDelegate">Deletage to callback after receive a message.</param>
         /// <param name="useCustomParser">Specifies if needs to use a custom parser for the response message.</param>
-        void ConnectToWebSocket<T>(string parameters, MessageHandler<T> messageDelegate, bool useCustomParser = false);
+        WebSocket ConnectToWebSocket<T>(string parameters, MessageHandler<T> messageDelegate, bool useCustomParser = false);
 
         /// <summary>
         /// Connects to a UserData Websocket endpoint.

--- a/Binance.API.Csharp.Client.Domain/Interfaces/IBinanceClient.cs
+++ b/Binance.API.Csharp.Client.Domain/Interfaces/IBinanceClient.cs
@@ -7,6 +7,7 @@ using Binance.API.Csharp.Client.Models.WebSocket;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using WebSocketSharp;
 using static Binance.API.Csharp.Client.Domain.Abstract.ApiClientAbstract;
 
 namespace Binance.API.Csharp.Client.Domain.Interfaces
@@ -215,7 +216,7 @@ namespace Binance.API.Csharp.Client.Domain.Interfaces
         /// </summary>
         /// <param name="symbol">Ticker symbol.</param>
         /// <param name="depthHandler">Handler to be used when a message is received.</param>
-        void ListenDepthEndpoint(string symbol, MessageHandler<DepthMessage> messageHandler);
+        WebSocket ListenDepthEndpoint(string symbol, MessageHandler<DepthMessage> messageHandler);
 
         /// <summary>
         /// Listen to the Kline endpoint.
@@ -223,14 +224,14 @@ namespace Binance.API.Csharp.Client.Domain.Interfaces
         /// <param name="symbol">Ticker symbol.</param>
         /// <param name="interval">Time interval to retreive.</param>
         /// <param name="klineHandler">Handler to be used when a message is received.</param>
-        void ListenKlineEndpoint(string symbol, TimeInterval interval, MessageHandler<KlineMessage> messageHandler);
+        WebSocket ListenKlineEndpoint(string symbol, TimeInterval interval, MessageHandler<KlineMessage> messageHandler);
 
         /// <summary>
         /// Listen to the Trades endpoint.
         /// </summary>
         /// <param name="symbol">Ticker symbol.</param>
         /// <param name="tradeHandler">Handler to be used when a message is received.</param>
-        void ListenTradeEndpoint(string symbol, MessageHandler<AggregateTradeMessage> messageHandler);
+        WebSocket ListenTradeEndpoint(string symbol, MessageHandler<AggregateTradeMessage> messageHandler);
 
         /// <summary>
         /// Listen to the User Data endpoint.

--- a/Binance.API.Csharp.Client/ApiClient.cs
+++ b/Binance.API.Csharp.Client/ApiClient.cs
@@ -97,7 +97,7 @@ namespace Binance.API.Csharp.Client
         /// <param name="parameters">Paremeters to send to the Websocket.</param>
         /// <param name="messageDelegate">Deletage to callback after receive a message.</param>
         /// <param name="useCustomParser">Specifies if needs to use a custom parser for the response message.</param>
-        public void ConnectToWebSocket<T>(string parameters, MessageHandler<T> messageHandler, bool useCustomParser = false)
+        public WebSocket ConnectToWebSocket<T>(string parameters, MessageHandler<T> messageHandler, bool useCustomParser = false)
         {
             var finalEndpoint = _webSocketEndpoint + parameters;
 
@@ -132,6 +132,7 @@ namespace Binance.API.Csharp.Client
 
             ws.Connect();
             _openSockets.Add(ws);
+            return ws;
         }
 
         /// <summary>

--- a/Binance.API.Csharp.Client/BinanceClient.cs
+++ b/Binance.API.Csharp.Client/BinanceClient.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using WebSocketSharp;
 
 namespace Binance.API.Csharp.Client
 {
@@ -563,7 +564,7 @@ namespace Binance.API.Csharp.Client
         /// </summary>
         /// <param name="symbol">Ticker symbol.</param>
         /// <param name="depthHandler">Handler to be used when a message is received.</param>
-        public void ListenDepthEndpoint(string symbol, ApiClientAbstract.MessageHandler<DepthMessage> depthHandler)
+        public WebSocket ListenDepthEndpoint(string symbol, ApiClientAbstract.MessageHandler<DepthMessage> depthHandler)
         {
             if (string.IsNullOrWhiteSpace(symbol))
             {
@@ -571,7 +572,7 @@ namespace Binance.API.Csharp.Client
             }
 
             var param = symbol + "@depth";
-            _apiClient.ConnectToWebSocket(param, depthHandler, true);
+            return _apiClient.ConnectToWebSocket(param, depthHandler, true);
         }
 
         /// <summary>
@@ -580,7 +581,7 @@ namespace Binance.API.Csharp.Client
         /// <param name="symbol">Ticker symbol.</param>
         /// <param name="interval">Time interval to retreive.</param>
         /// <param name="klineHandler">Handler to be used when a message is received.</param>
-        public void ListenKlineEndpoint(string symbol, TimeInterval interval, ApiClientAbstract.MessageHandler<KlineMessage> klineHandler)
+        public WebSocket ListenKlineEndpoint(string symbol, TimeInterval interval, ApiClientAbstract.MessageHandler<KlineMessage> klineHandler)
         {
             if (string.IsNullOrWhiteSpace(symbol))
             {
@@ -588,7 +589,7 @@ namespace Binance.API.Csharp.Client
             }
 
             var param = symbol + $"@kline_{interval.GetDescription()}";
-            _apiClient.ConnectToWebSocket(param, klineHandler);
+            return _apiClient.ConnectToWebSocket(param, klineHandler);
         }
 
         /// <summary>
@@ -596,7 +597,7 @@ namespace Binance.API.Csharp.Client
         /// </summary>
         /// <param name="symbol">Ticker symbol.</param>
         /// <param name="tradeHandler">Handler to be used when a message is received.</param>
-        public void ListenTradeEndpoint(string symbol, ApiClientAbstract.MessageHandler<AggregateTradeMessage> tradeHandler)
+        public WebSocket ListenTradeEndpoint(string symbol, ApiClientAbstract.MessageHandler<AggregateTradeMessage> tradeHandler)
         {
             if (string.IsNullOrWhiteSpace(symbol))
             {
@@ -604,7 +605,7 @@ namespace Binance.API.Csharp.Client
             }
 
             var param = symbol + "@aggTrade";
-            _apiClient.ConnectToWebSocket(param, tradeHandler);
+            return _apiClient.ConnectToWebSocket(param, tradeHandler);
         }
 
         /// <summary>


### PR DESCRIPTION
For a better usability it is needed to manage the websocket connection e.g. to add some events or to close the connection from the client side when the websocket is no longer needed.