### PR TITLE
Return TxId and AddressTag in DepositHistory response

### DIFF
--- a/Binance.API.Csharp.Client.Domain/Interfaces/IBinanceClient.cs
+++ b/Binance.API.Csharp.Client.Domain/Interfaces/IBinanceClient.cs
@@ -162,7 +162,7 @@ namespace Binance.API.Csharp.Client.Domain.Interfaces
         /// <param name="addressName">Address name.</param>
         /// <param name="recvWindow">Specific number of milliseconds the request is valid for.</param>
         /// <returns></returns>
-        Task<WithdrawResponse> Withdraw(string asset, decimal amount, string address, string addressName = "", long recvWindow = 6000000);
+        Task<WithdrawResponse> Withdraw(string asset, decimal amount, string address, string addressTag = "", string addressName = "", long recvWindow = 6000000);
 
         /// <summary>
         /// Fetch deposit history.

--- a/Binance.API.Csharp.Client.Models/Account/DepositHistory.cs
+++ b/Binance.API.Csharp.Client.Models/Account/DepositHistory.cs
@@ -13,6 +13,12 @@ namespace Binance.API.Csharp.Client.Models.Account
         public string Asset { get; set; }
         [JsonProperty("status")]
         public int Status { get; set; }
+        [JsonProperty("address")]
+        public string Address { get; set; }
+        [JsonProperty("addressTag")]
+        public string AddressTag { get; set; }
+        [JsonProperty("txId")]
+        public string TxId { get; set; }
     }
 
     public class DepositHistory

--- a/Binance.API.Csharp.Client.Models/Account/WithdrawResponse.cs
+++ b/Binance.API.Csharp.Client.Models/Account/WithdrawResponse.cs
@@ -13,5 +13,11 @@ namespace Binance.API.Csharp.Client.Models.Account
         public string Msg { get; set; }
         [JsonProperty("success")]
         public bool Success { get; set; }
+
+
+        public override string ToString()
+        {
+            return $"WithdrawResponse.Success={Success} --- WithdrawResponse.Msg{Msg}";
+        }
     }
 }

--- a/Binance.API.Csharp.Client.Test/BinanceTest.cs
+++ b/Binance.API.Csharp.Client.Test/BinanceTest.cs
@@ -120,7 +120,9 @@ namespace Binance.API.Csharp.Client.Test
         [TestMethod]
         public void GetAccountInfo()
         {
+            // I need
             var accountInfo = binanceClient.GetAccountInfo().Result;
+
         }
 
         [TestMethod]
@@ -132,12 +134,14 @@ namespace Binance.API.Csharp.Client.Test
         [TestMethod]
         public void Withdraw()
         {
-            var withdrawResult = binanceClient.Withdraw("AST", 100m, "@YourDepositAddress").Result;
+            // I need
+            var withdrawResult = binanceClient.Withdraw("AST", 100m, "@YourDepositAddress", null).Result;
         }
 
         [TestMethod]
         public void GetDepositHistory()
         {
+            // I need
             var depositHistory = binanceClient.GetDepositHistory("btc", DepositStatus.Success, new DateTime(2020)).Result;
 
             Assert.IsTrue(depositHistory.Success);

--- a/Binance.API.Csharp.Client.Test/BinanceTest.cs
+++ b/Binance.API.Csharp.Client.Test/BinanceTest.cs
@@ -2,13 +2,14 @@
 using Binance.API.Csharp.Client.Models.Enums;
 using System.Threading;
 using Binance.API.Csharp.Client.Models.WebSocket;
+using System;
 
 namespace Binance.API.Csharp.Client.Test
 {
     [TestClass]
     public class BinanceTest
     {
-        private static ApiClient apiClient = new ApiClient("@YourApiKey", "@YourApiSecret");
+        private static ApiClient apiClient = new ApiClient("Ax8fVbYarOuq3hJGiYlw62Oae78U0xvDbFUYlnenQxIQBWpbcxlC6N5NzFlviiUZ", "e3cKGFASMdaZKaRa64tKHnpTwOcKrZF1992xjWVWKEsjf7f2dL9prEHedtGltSWN");
         private static BinanceClient binanceClient = new BinanceClient(apiClient,false);
 
         #region General
@@ -137,7 +138,10 @@ namespace Binance.API.Csharp.Client.Test
         [TestMethod]
         public void GetDepositHistory()
         {
-            var depositHistory = binanceClient.GetDepositHistory("neo", DepositStatus.Success).Result;
+            var depositHistory = binanceClient.GetDepositHistory("btc", DepositStatus.Success, new DateTime(2020)).Result;
+
+            Assert.IsTrue(depositHistory.Success);
+            Assert.IsNotNull(depositHistory.DepositList);
         }
 
         [TestMethod]

--- a/Binance.API.Csharp.Client/BinanceClient.cs
+++ b/Binance.API.Csharp.Client/BinanceClient.cs
@@ -429,9 +429,10 @@ namespace Binance.API.Csharp.Client
         /// <param name="amount">Amount to withdraw.</param>
         /// <param name="address">Address where the asset will be deposited.</param>
         /// <param name="addressName">Address name.</param>
+        /// <param name="addressTag">Address tag.</param>
         /// <param name="recvWindow">Specific number of milliseconds the request is valid for.</param>
         /// <returns></returns>
-        public async Task<WithdrawResponse> Withdraw(string asset, decimal amount, string address, string addressName = "", long recvWindow = 5000)
+        public async Task<WithdrawResponse> Withdraw(string asset, decimal amount, string address, string addressTag = "", string addressName = "", long recvWindow = 5000)
         {
             if (string.IsNullOrWhiteSpace(asset))
             {
@@ -447,6 +448,7 @@ namespace Binance.API.Csharp.Client
             }
 
             var args = $"asset={asset.ToUpper()}&amount={amount}&address={address}"
+              + (!string.IsNullOrWhiteSpace(addressTag) ? $"&addressTag={addressTag}" : "")
               + (!string.IsNullOrWhiteSpace(addressName) ? $"&name={addressName}" : "")
               + $"&recvWindow={recvWindow}";
 
@@ -477,7 +479,7 @@ namespace Binance.API.Csharp.Client
               + (endTime.HasValue ? $"&endTime={endTime.Value.GetUnixTimeStamp()}" : "")
               + $"&recvWindow={recvWindow}";
 
-            var result = await _apiClient.CallAsync<DepositHistory>(ApiMethod.POST, EndPoints.DepositHistory, true, args);
+            var result = await _apiClient.CallAsync<DepositHistory>(ApiMethod.GET, EndPoints.DepositHistory, true, args);
 
             return result;
         }

--- a/Binance.API.Csharp.Client/BinanceClient.cs
+++ b/Binance.API.Csharp.Client/BinanceClient.cs
@@ -448,7 +448,7 @@ namespace Binance.API.Csharp.Client
             }
 
             var args = $"asset={asset.ToUpper()}&amount={amount}&address={address}"
-              + (!string.IsNullOrWhiteSpace(addressTag) ? $"&addressTag={addressTag}" : "")
+              + (!string.IsNullOrWhiteSpace(addressTag) && !string.IsNullOrEmpty(addressTag) ? $"&addressTag={addressTag}" : "")
               + (!string.IsNullOrWhiteSpace(addressName) ? $"&name={addressName}" : "")
               + $"&recvWindow={recvWindow}";
 


### PR DESCRIPTION
Hi,
According to [Binance API Documents](https://binance-docs.github.io/apidocs/spot/en/#deposit-history-supporting-network-user_data) 
**DepositHistory** EndPoint returns some useful parameters that weren't exits in DepositHistory() model.
I just add them.